### PR TITLE
Changed e-mail for adresse électronique

### DIFF
--- a/i18n/fr.i18n.json
+++ b/i18n/fr.i18n.json
@@ -28,11 +28,11 @@
         },
         "1": {
           "exp": "SimpleSchema.RegEx.Email",
-          "msg": "[label] doit être une adresse e-mail valide"
+          "msg": "[label] doit être une adresse électronique valide"
         },
         "2": {
           "exp": "SimpleSchema.RegEx.WeakEmail",
-          "msg": "[label] doit être une adresse e-mail valide"
+          "msg": "[label] doit être une adresse électronique valide"
         },
         "3": {
           "exp": "SimpleSchema.RegEx.Domain",


### PR DESCRIPTION
E-mail is not an official french word, the current name is "adresse électronique" or "adresse courriel"
