### PR TITLE
Meteor 1.2 & package bumped

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,15 +1,15 @@
 Package.describe({
   name: "gwendall:simple-schema-i18n",
   summary: "Internationalization for SimpleSchema",
-  version: "0.1.9",
+  version: "0.2.0",
   git: "https://github.com/gwendall/meteor-simple-schema-i18n.git"
 });
 
 var packages = [
   "aldeed:simple-schema@1.3.2",
-  "tap:i18n@1.4.1",
-  "templating@1.1.1",
-  "underscore@1.0.3"
+  "tap:i18n@1.6.1",
+  "templating@1.1.4",
+  "underscore@1.0.4"
 ];
 
 Package.onUse(function (api, where) {
@@ -18,7 +18,7 @@ Package.onUse(function (api, where) {
   api.imply(packages);
 
   api.addFiles([
-    "package-tap.i18n",
+    "shared/lib.js",
     "i18n/ar.i18n.json",
     "i18n/bg.i18n.json",
     "i18n/de.i18n.json",
@@ -38,8 +38,9 @@ Package.onUse(function (api, where) {
     "i18n/uk.i18n.json",
     "i18n/zh-CN.i18n.json",
     "i18n/zh-HK.i18n.json",
-    "i18n/zh-TW.i18n.json",
-    "shared/lib.js"
+    "i18n/zh-TW.i18n.json"
   ]);
-
+  api.addAssets([
+    "package-tap.i18n"
+  ], ['client', 'server']);
 });


### PR DESCRIPTION
- `addAsset` instead of `addFiles` for `*.i18n`.
- Bumps all dependencies to their latest release.
